### PR TITLE
Cache S3 data in database to improve backfill speed and reduce s3 costs

### DIFF
--- a/rust/main/agents/validator/src/validator.rs
+++ b/rust/main/agents/validator/src/validator.rs
@@ -84,7 +84,7 @@ impl BaseAgent for Validator {
         // a fatal startup error.
         let checkpoint_syncer = settings
             .checkpoint_syncer
-            .build_and_validate(None)
+            .build_and_validate(None, msg_db.clone())
             .await
             .expect("Failed to build checkpoint syncer")
             .into();

--- a/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
@@ -36,6 +36,7 @@ const MERKLE_LEAF_INDEX_BY_MESSAGE_ID: &str = "merkle_leaf_index_by_message_id_"
 const MERKLE_TREE_INSERTION_BLOCK_NUMBER_BY_LEAF_INDEX: &str =
     "merkle_tree_insertion_block_number_by_leaf_index_";
 const LATEST_INDEXED_GAS_PAYMENT_BLOCK: &str = "latest_indexed_gas_payment_block";
+pub const SUBMITTED_CHECKPOINT_PREFIX: &str = "submitted_checkpoint";
 
 /// Rocks DB result type
 pub type DbResult<T> = std::result::Result<T, DbError>;
@@ -659,7 +660,7 @@ impl HyperlaneDb for HyperlaneRocksDB {
 }
 
 impl HyperlaneRocksDB {
-    fn store_value_by_key<K: Encode, V: Encode>(
+    pub fn store_value_by_key<K: Encode, V: Encode>(
         &self,
         prefix: impl AsRef<[u8]>,
         key: &K,
@@ -668,7 +669,7 @@ impl HyperlaneRocksDB {
         self.store_encodable(prefix, key.to_vec(), value)
     }
 
-    fn retrieve_value_by_key<K: Encode, V: Decode>(
+    pub fn retrieve_value_by_key<K: Encode, V: Decode>(
         &self,
         prefix: impl AsRef<[u8]>,
         key: &K,


### PR DESCRIPTION
### Description

While monitoring metrics in #3, Tessellated discovered that backfills could often take long to complete. For instance, some chains like Optimism would spend days backfilling. 

This is because during backfill, the validator client makes a network request to s3 to verify that the checkpoint is there. If it isn't then it signs / uploads a checkpoint. This happens on every binary restart.

From a time perspective, this isn't efficient. It also increases the cost of using AWS to store signatures (since validators pay for transfer bandwidth) and it increases network egress costs for the requesting machine. To solve this, we cache checkpoints that we've written to S3 or that we've fetched from S3 into the database. 

Benchmarks (anecdotal, would be happy to run better tests):
- Backfill time for Optimism: 1.5 days -> 90 seconds 
- Disk Usage: +15GB for implementing this for 24 chains

This is a proof of concept PR that shows how we can store signed / fetched checkpoints into the local database. If we end up wanting to upstream this PR, I'd be happy to clean this up to have better abstractions. Specifically I'd want to:
- Separate caching functionality from S3 storage, likely using a decorator pattern (which in turn would make this applicable to all storage types, now and in the future)
- Potentially hide this functionality behind a feature flag so it is opt in
- Fix DB methods to use higher level abstractions

