### PR TITLE
Support Multiple Validators in a single process

### DIFF
--- a/rust/main/agents/validator/src/main.rs
+++ b/rust/main/agents/validator/src/main.rs
@@ -14,7 +14,7 @@ mod settings;
 mod submit;
 mod validator;
 
-#[tokio::main(flavor = "current_thread")]
+#[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
     // Logging is not initialised at this point, so, using `println!`
     println!("Validator starting up...");

--- a/rust/main/agents/validator/src/settings.rs
+++ b/rust/main/agents/validator/src/settings.rs
@@ -22,13 +22,22 @@ use serde::Deserialize;
 use serde_json::Value;
 
 /// Settings for `Validator`
-#[derive(Debug, AsRef, AsMut, Deref, DerefMut)]
+#[derive(Clone, Debug, AsRef, AsMut, Deref, DerefMut)]
 pub struct ValidatorSettings {
     #[as_ref]
     #[as_mut]
     #[deref]
     #[deref_mut]
     base: Settings,
+    pub validators: Vec<ChainValidatorSettings>,
+}
+
+#[derive(Clone, Debug, AsRef, AsMut, Deref, DerefMut)]
+pub struct ChainValidatorSettings {
+    #[as_ref]
+    #[as_mut]
+    #[deref]
+    #[deref_mut]
 
     /// Database path
     pub db: PathBuf,
@@ -60,29 +69,15 @@ impl FromRawConf<RawValidatorSettings> for ValidatorSettings {
 
         let p = ValueParser::new(cwp.clone(), &raw.0);
 
-        let origin_chain_name = p
-            .chain(&mut err)
-            .get_key("originChainName")
-            .parse_string()
-            .end();
-
-        let origin_chain_name_set = origin_chain_name.map(|s| HashSet::from([s]));
-
+        // Parse the base config
+        // NOTE: Hyperlane mainline filters to a specific origin chain on their mainline repo,
+        // but since this fork supports multiple origin chains, we pass None as the filter.
         let base: Option<Settings> = p
             .parse_from_raw_config::<Settings, RawAgentConf, Option<&HashSet<&str>>>(
-                origin_chain_name_set.as_ref(),
+                None,
                 "Expected valid base agent configuration",
             )
             .take_config_err(&mut err);
-
-        let origin_chain = if let (Some(base), Some(origin_chain_name)) = (&base, origin_chain_name)
-        {
-            base.lookup_domain(origin_chain_name)
-                .context("Missing configuration for the origin chain")
-                .take_err(&mut err, || cwp + "origin_chain_name")
-        } else {
-            None
-        };
 
         let validator = p
             .chain(&mut err)
@@ -93,15 +88,9 @@ impl FromRawConf<RawValidatorSettings> for ValidatorSettings {
             )
             .end();
 
-        let db = p
-            .chain(&mut err)
-            .get_opt_key("db")
-            .parse_from_str("Expected db file path")
-            .unwrap_or_else(|| {
-                std::env::current_dir()
-                    .unwrap()
-                    .join(format!("validator_db_{}", origin_chain_name.unwrap_or("")))
-            });
+        // Parse root db path
+        // When creating validator configs, a /<chain> will be automatically appended
+        let db_root_path = p.chain(&mut err).get_key("db").parse_string().end();
 
         let checkpoint_syncer = p
             .chain(&mut err)
@@ -109,44 +98,97 @@ impl FromRawConf<RawValidatorSettings> for ValidatorSettings {
             .and_then(parse_checkpoint_syncer)
             .end();
 
-        let interval = p
+        // Do not set interval, it is automatically computed.
+        let interval = p.chain(&mut err).get_opt_key("interval").parse_u64().end();
+        if let Some(_) = interval {
+            panic!("do not set interval, it is computed automatically");
+        }
+
+        // Get active chains
+        let origin_chain_names = p
             .chain(&mut err)
-            .get_opt_key("interval")
-            .parse_u64()
-            .map(Duration::from_secs)
-            .unwrap_or(Duration::from_secs(5));
+            .get_key("originchainnames")
+            .into_array_iter()
+            .map(|items| {
+                let parsed = items.map(|v| {
+                    let origin_chain = v.chain(&mut err).parse_string().end().unwrap();
 
-        cfg_unwrap_all!(cwp, err: [origin_chain_name]);
+                    origin_chain.to_owned()
+                });
+                let collected = parsed.collect::<Vec<String>>();
 
-        let reorg_period = p
-            .chain(&mut err)
-            .get_key("chains")
-            .get_key(origin_chain_name)
-            .get_opt_key("blocks")
-            .get_opt_key("reorgPeriod")
-            .parse_value("Invalid reorgPeriod")
-            .unwrap_or(ReorgPeriod::from_blocks(1));
+                collected
+            })
+            .unwrap();
 
-        cfg_unwrap_all!(cwp, err: [base, origin_chain, validator, checkpoint_syncer]);
+        cfg_unwrap_all!(cwp, err: [base, validator, checkpoint_syncer, db_root_path]);
 
-        let mut base: Settings = base;
-        // If the origin chain is an EVM chain, then we can use the validator as the signer if needed.
-        if origin_chain.domain_protocol() == HyperlaneDomainProtocol::Ethereum {
-            if let Some(origin) = base.chains.get_mut(origin_chain.name()) {
-                origin.signer.get_or_insert_with(|| validator.clone());
-            }
+        // Build a validator config for each validator
+        let mut validators: Vec<ChainValidatorSettings> = vec![];
+        for origin_chain_name in origin_chain_names {
+            let validator: Result<ChainValidatorSettings, ConfigParsingError> = parse_validator(
+                &base,
+                cwp,
+                db_root_path,
+                checkpoint_syncer.clone(),
+                validator.clone(),
+                origin_chain_name.as_str(),
+            );
+            validators.push(validator.unwrap());
         }
 
         err.into_result(Self {
-            base,
-            db,
-            origin_chain,
-            validator,
-            checkpoint_syncer,
-            reorg_period,
-            interval,
+            base: base,
+            validators,
         })
     }
+}
+
+fn parse_validator(
+    base: &Settings,
+    cwp: &ConfigPath,
+    db_root_path: &str,
+    mut checkpoint_syncer: CheckpointSyncerConf,
+    validator: SignerConf,
+    origin_chain_name: &str,
+) -> Result<ChainValidatorSettings, ConfigParsingError> {
+    let mut err: ConfigParsingError = ConfigParsingError::default();
+    let origin_chain = base
+        .lookup_domain(origin_chain_name)
+        .context("Missing configuration for the origin chain")
+        .take_err(&mut err, || cwp + "origin_chain_name");
+
+    cfg_unwrap_all!(cwp, err: [origin_chain]);
+
+    // Automatically append the origin chain name to both the db path and the s3 checkpoint syncer
+    let subfolder = format!("{}", origin_chain_name);
+    let db_path = format!("{}/{}", db_root_path, subfolder);
+
+    if let CheckpointSyncerConf::S3 { folder, .. } = &mut checkpoint_syncer {
+        match folder {
+            Some(ref mut existing_folder) => existing_folder.push_str(&subfolder),
+            None => *folder = Some(subfolder),
+        }
+    }
+
+    // Automatically set interval to be one block
+    let chain_config = base.chains.get(origin_chain_name);
+    cfg_unwrap_all!(cwp, err: [chain_config]);
+
+    // TODO: Determine the correct interval to use.
+    let interval = Duration::from_secs(30);
+
+    // Get chain config, which is needed to find the reorg period
+    let reorg_period = chain_config.reorg_period.clone();
+
+    err.into_result(ChainValidatorSettings {
+        db: db_path.into(),
+        origin_chain,
+        validator,
+        checkpoint_syncer,
+        reorg_period,
+        interval,
+    })
 }
 
 /// Expects ValidatorAgentConfig.checkpointSyncer

--- a/rust/main/hyperlane-base/src/metadata.rs
+++ b/rust/main/hyperlane-base/src/metadata.rs
@@ -2,7 +2,7 @@ use derive_new::new;
 use serde::{Deserialize, Serialize};
 
 /// Metadata about agent
-#[derive(Debug, Deserialize, Serialize, new)]
+#[derive(Clone, Debug, Deserialize, Serialize, new)]
 pub struct AgentMetadata {
     /// Contains git commit hash of the agent binary
     pub git_sha: String,

--- a/rust/main/hyperlane-base/src/metrics/runtime_metrics.rs
+++ b/rust/main/hyperlane-base/src/metrics/runtime_metrics.rs
@@ -12,6 +12,7 @@ use super::CoreMetrics;
 const RUNTIME_DROPPED_TASKS_HELP: &str = "The number of tasks dropped";
 
 /// Metrics for the runtime
+#[derive(Clone)]
 pub struct RuntimeMetrics {
     producer: TaskMonitor,
     dropped_tasks: IntCounter,

--- a/rust/main/hyperlane-base/src/settings/base.rs
+++ b/rust/main/hyperlane-base/src/settings/base.rs
@@ -44,7 +44,7 @@ use super::TryFromWithMetrics;
 ///     }
 /// }
 /// ```
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Settings {
     /// Configuration for contracts on each chain
     pub chains: HashMap<String, ChainConf>,


### PR DESCRIPTION
### Description

This PR enables multiple validators to run in a single process. 

This introduces a few changes to the settings file and how settings are parsed:
- DB paths are automatically namespaced with the chain name as a subfolder
- S3 buckets are automatically namespaced with the chain name as a subfolder
- The field `originchainname` (type `string`) becomes `originchainnames` (type `array<string>`) 

Besides setting parsing the implementation:
- Renames `Validator/ValidatorSettings` to `ChainValidator/ChainValidatorSettings`. Logically this is a validator bound to a single chain
- Creates a new `Validator/ValidatorSettings` struct in it's place, which is a class that holds singleton object and one or more `ChainValidator`s.

Other than that changes are fairly straightforward:
- Use multithreaded tokio runtime since we're now doing parallelizable work and using a single thread tends to starve the tokio runtime since some tasks (ie. backfill) are long running
- Break API server out and have it run once, rather than once per validator (otherwise it will fail since it will try to bind the same port `n` times
- Instrument `tokio_spawn` with chain names so that we can tell which chain is producting logs
- Break out metrics as a singleton so each `ChainValidator` can update metrics

Open Questions:
- Does `interval` need to vary on a chain by chain basis or can it be set to. static value for all chains
- How do we maintain backward compatibility with existing settings files?